### PR TITLE
Avoid major eslint version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    ignore:
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
     groups:
       everything:
         patterns:


### PR DESCRIPTION
This PR locks in the current eslint major version (for now).

Once the ecosystem has caught up with eslint 9 we can remove this ignore line.

Resolves #62 